### PR TITLE
Fix channel order

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: minerl
 channels:
+  - pytorch
   - conda-forge
   - defaults
-  - pytorch
 dependencies:
   - python=3.7
   - pip


### PR DESCRIPTION
pytorch should be the top in this case to refer to pytorch channel to get Pytorch package with cuda.